### PR TITLE
Fix circular import and update middleware documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,9 +37,9 @@ Note: the root `README.md` references `dev:server`, `dev:worker`, `dev:all`, `bu
 2. `loggerMiddleware`, `performanceMiddleware`
 3. `localeMiddleware` — parses `Accept-Language` header and sets locale via `AsyncLocalStorage`
 4. `diMiddleware` — injects services from the DI container into `c.var`
-4. `bodyLimitMiddleware`, `corsMiddleware`, `securityHeadersMiddleware`, `rateLimiterMiddleware`
-5. `registerException(app)` — centralized error handler (see `src/libs/hono/errors/error.handler.ts`)
-6. `app.route("/", bootstrap)` mounts `src/modules/index.ts`, which wires `/`, `/auth`, `/profile`, `/settings`, plus `/docs` (Scalar) and `/docs/openapi.json`.
+5. `bodyLimitMiddleware`, `corsMiddleware`, `securityHeadersMiddleware`, `rateLimiterMiddleware`
+6. `registerException(app)` — centralized error handler (see `src/libs/hono/errors/error.handler.ts`)
+7. `app.route("/", bootstrap)` mounts `src/modules/index.ts`, which wires `/`, `/auth`, `/profile`, `/settings`, plus `/docs` (Scalar) and `/docs/openapi.json`.
 
 ### Dependency injection
 

--- a/src/libs/config/config.validator.ts
+++ b/src/libs/config/config.validator.ts
@@ -12,7 +12,7 @@ import type {
 	MailConfig,
 	ClickHouseConfig,
 } from "@types";
-import { logger } from "@utils";
+import { logger } from "@utils/hono/logger";
 
 /**
  * Validates a URL format


### PR DESCRIPTION
This pull request makes minor improvements to documentation and refactors an import for clarity and specificity. The changes are straightforward and do not affect application logic.

- In `CLAUDE.md`, the middleware and routing steps are renumbered for accuracy and clarity.
- In `src/libs/config/config.validator.ts`, the `logger` import is updated to use a more specific path: `@utils/hono/logger`.